### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,9 @@
 
 name: Node.js Package
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -37,6 +40,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.event.inputs.publish_to_npm == 'true'
+    permissions:
+      contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/Pratyay360/upiqrcode/security/code-scanning/1](https://github.com/Pratyay360/upiqrcode/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define minimal permissions for all jobs. Additionally, we will add job-specific `permissions` blocks where necessary to grant additional permissions required for specific tasks. For example, the `publish-npm` job requires `contents: write` to update the repository and `packages: write` to publish to npm.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
